### PR TITLE
Add attribute autocorrect to BaseTextField

### DIFF
--- a/packages/base_text_field/lib/src/base_text_field.dart
+++ b/packages/base_text_field/lib/src/base_text_field.dart
@@ -46,7 +46,10 @@ class BaseTextField extends StatefulWidget {
   /// Called when the user tap the "continue" button on the keyboard
   /// When there is no method provided (or the method/callback is null), the keyboard will be closed
   final VoidCallback? onEditingComplete;
+
   final bool obscureText;
+
+  final bool autocorrect;
 
   const BaseTextField({
     required this.text,
@@ -69,6 +72,7 @@ class BaseTextField extends StatefulWidget {
     this.onLeave,
     this.onEditingComplete,
     this.obscureText = false,
+    this.autocorrect = true,
     this.inputFormatter,
     Key? key,
   }) : super(key: key);
@@ -163,6 +167,7 @@ class BaseTextFieldState extends State<BaseTextField>
           ? widget.textStyleMutator!(style)
           : style,
       obscureText: widget.obscureText,
+      autocorrect: widget.autocorrect,
       focusNode: _focusNode,
       controller: _textEditingController,
       // use onChange instead of [TextEditingController.addListener]


### PR DESCRIPTION
Extend BaseTextField by the attribute autocorrect=true, which is passed to the underling TextFormField. This makes it possible to disable the autocorrect function of a BaseTextField.