### PR TITLE
Add attribute autocorrect to BaseTextField

### DIFF
--- a/lib/src/text_field/base_text_field.dart
+++ b/lib/src/text_field/base_text_field.dart
@@ -48,7 +48,10 @@ class BaseTextField extends StatefulWidget {
   /// Called when the user tap the "continue" button on the keyboard
   /// When there is no method provided (or the method/callback is null), the keyboard will be closed
   final VoidCallback? onEditingComplete;
+
   final bool obscureText;
+
+  final bool autocorrect;
 
   const BaseTextField({
     required this.text,
@@ -72,6 +75,7 @@ class BaseTextField extends StatefulWidget {
     this.onLeave,
     this.onEditingComplete,
     this.obscureText = false,
+    this.autocorrect = true,
     this.inputFormatter,
     Key? key,
   }) : super(key: key);
@@ -170,6 +174,7 @@ class BaseTextFieldState extends State<BaseTextField>
           ? widget.textStyleMutator!(style)
           : style,
       obscureText: widget.obscureText,
+      autocorrect: widget.autocorrect,
       focusNode: _focusNode,
       controller: _textEditingController,
       // use onChange instead of [TextEditingController.addListener]

--- a/lib/src/text_field/base_text_field.dart
+++ b/lib/src/text_field/base_text_field.dart
@@ -53,6 +53,8 @@ class BaseTextField extends StatefulWidget {
 
   final bool autocorrect;
 
+  final bool enableSuggestions;
+
   /// Defines the state of the keyboard (uppercase or lowercase) when selecting the TextField
   final TextCapitalization textCapitalization;
 
@@ -80,6 +82,7 @@ class BaseTextField extends StatefulWidget {
     this.onEditingComplete,
     this.obscureText = false,
     this.autocorrect = true,
+    this.enableSuggestions = true,
     this.inputFormatter,
     Key? key,
   }) : super(key: key);
@@ -180,6 +183,7 @@ class BaseTextFieldState extends State<BaseTextField>
       textCapitalization: widget.textCapitalization,
       obscureText: widget.obscureText,
       autocorrect: widget.autocorrect,
+      enableSuggestions: widget.enableSuggestions,
       focusNode: _focusNode,
       controller: _textEditingController,
       // use onChange instead of [TextEditingController.addListener]

--- a/lib/src/text_field/base_text_field.dart
+++ b/lib/src/text_field/base_text_field.dart
@@ -53,6 +53,9 @@ class BaseTextField extends StatefulWidget {
 
   final bool autocorrect;
 
+  /// Defines the state of the keyboard (uppercase or lowercase) when selecting the TextField
+  final TextCapitalization textCapitalization;
+
   const BaseTextField({
     required this.text,
     required this.onChanged,
@@ -61,6 +64,7 @@ class BaseTextField extends StatefulWidget {
     this.onFieldSubmitted,
     this.onValidationChanged,
     this.textInputType,
+    this.textCapitalization = TextCapitalization.none,
     this.focusNode,
     this.validator,
     this.textStyleMutator,
@@ -173,6 +177,7 @@ class BaseTextFieldState extends State<BaseTextField>
       style: widget.textStyleMutator != null
           ? widget.textStyleMutator!(style)
           : style,
+      textCapitalization: widget.textCapitalization,
       obscureText: widget.obscureText,
       autocorrect: widget.autocorrect,
       focusNode: _focusNode,


### PR DESCRIPTION
Extend BaseTextField by the attribute autocorrect=true, which is passed to the underling TextFormField. This makes it possible to disable the autocorrect function of a BaseTextField.